### PR TITLE
Add main base view components

### DIFF
--- a/src/main/java/com/crhistianm/netrwoon/components/CommandPanel.java
+++ b/src/main/java/com/crhistianm/netrwoon/components/CommandPanel.java
@@ -1,0 +1,38 @@
+package com.crhistianm.netrwoon.components;
+
+import java.awt.Component;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+class CommandPanel extends JPanel{
+
+    private CommandTextField commandTextField;
+
+    private JLabel commandLabel;
+
+    CommandPanel() {
+        commandTextField = new CommandTextField();
+        commandLabel = new JLabel();
+        commandLabel.setSize(commandLabel.getSize().width +1, commandLabel.getSize().height + 1);
+        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+
+        commandLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
+        commandTextField.setAlignmentY(Component.CENTER_ALIGNMENT);
+
+        add(commandLabel);
+        add(Box.createHorizontalStrut(8));
+        add(commandTextField);
+    }
+
+    CommandTextField getCommandTextField() {
+        return commandTextField;
+    }
+    
+    JLabel getCommandLabel() {
+        return commandLabel;
+    }
+    
+}

--- a/src/main/java/com/crhistianm/netrwoon/components/CommandTextField.java
+++ b/src/main/java/com/crhistianm/netrwoon/components/CommandTextField.java
@@ -1,0 +1,26 @@
+package com.crhistianm.netrwoon.components;
+
+import javax.swing.JTextField;
+
+import com.crhistianm.netrwoon.utils.CommandOperationType;
+
+public class CommandTextField extends JTextField {
+
+    private CommandOperationType currentOperation = CommandOperationType.NONE;
+
+    CommandTextField() {
+        this.setEnabled(false);
+        this.setEditable(false);
+        this.setFocusable(true);
+        this.setSize(20, 20);
+    }
+
+    public void setCurrentOperation(CommandOperationType currentOperation) {
+        this.currentOperation = currentOperation;
+    }
+
+    public CommandOperationType getCurrentOperation() {
+        return currentOperation;
+    }
+
+}

--- a/src/main/java/com/crhistianm/netrwoon/components/NetrwoonDialogWrapper.java
+++ b/src/main/java/com/crhistianm/netrwoon/components/NetrwoonDialogWrapper.java
@@ -1,0 +1,71 @@
+package com.crhistianm.netrwoon.components;
+
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.wm.WindowManager;
+import com.intellij.ui.components.JBList;
+
+public class NetrwoonDialogWrapper extends DialogWrapper {
+
+    private final NetrwoonMainView mainView;
+
+    public NetrwoonDialogWrapper(JBList<String> list, Project project) {
+        super(true);
+        getRootPane().getInputMap().clear();
+        loadSize(project);
+        mainView = new NetrwoonMainView(list);
+        setTitle("Netrwoon");
+        init();
+    }
+
+    private void loadSize(Project project){
+        Dimension ideSize = WindowManager.getInstance().getFrame(project).getSize();
+
+        this.setSize(ideSize.width, ideSize.height);
+    }
+
+    @Override
+    //Remove ok and cancel buttons
+    protected @NotNull JPanel createButtonsPanel(@NotNull List<? extends JButton> buttons) {
+        return new JPanel();
+    }
+
+    @Override
+    //Remove esc event
+    protected @Nullable ActionListener createCancelAction() {
+        return new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {}
+        };
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        return mainView.getPanel();
+    }
+
+    public void setPathText(String text) {
+        mainView.getPathLabel().setText(text);
+    }
+
+    public void setCommandLabelText(String text) {
+        mainView.getCommandLabel().setText(text);
+    }
+
+    public CommandTextField getCommandTextField() {
+        return mainView.getCommandTextField();
+    }
+
+}

--- a/src/main/java/com/crhistianm/netrwoon/components/NetrwoonMainView.java
+++ b/src/main/java/com/crhistianm/netrwoon/components/NetrwoonMainView.java
@@ -1,0 +1,129 @@
+package com.crhistianm.netrwoon.components;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.UIManager;
+
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBList;
+import static com.crhistianm.netrwoon.utils.Constants.HELP_LABEL_TEXT;
+
+class NetrwoonMainView{
+
+    private JLabel pathLabel;
+
+    private JLabel helpLabel;
+    
+    private JPanel panel;
+
+    private JScrollPane scrollListPane;
+
+    private CommandPanel commandPanel;
+
+    public NetrwoonMainView(){
+        panel = new JPanel(new GridBagLayout());
+        pathLabel = new JLabel();
+        helpLabel = new JLabel(HELP_LABEL_TEXT);
+        commandPanel = new CommandPanel();
+        scrollListPane = new JScrollPane();
+
+        panel.setFocusable(false);
+    }
+
+    public NetrwoonMainView(JBList<String> listComponent){
+        this();
+        loadIdeStyle();
+        listComponent.setBackground(JBColor.background());
+        listComponent.setForeground(JBColor.foreground());
+        loadComponents(listComponent);
+    }
+
+    private void loadComponents(JBList<String> listComponent){
+        GridBagConstraints c = new GridBagConstraints();
+
+        c.gridx = 0;
+        c.gridy = 0;
+        c.weightx = 0.0;
+        c.weighty = 0.1;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.anchor = GridBagConstraints.LINE_START;
+        panel.add(pathLabel, c);
+
+        c = new GridBagConstraints();
+
+        c.gridx = 0;
+        c.gridy = 1;
+        c.weightx = 0.0;
+        c.weighty = 0.1;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.anchor = GridBagConstraints.LINE_START;
+        panel.add(helpLabel, c);
+
+        c = new GridBagConstraints();
+        c.gridx = 0;
+        c.gridy = 2;
+        c.weightx = 1.0;
+        c.weighty = 0.9;
+        c.fill = GridBagConstraints.BOTH;
+        scrollListPane.setViewportView(listComponent);
+        panel.add(scrollListPane, c);
+
+        c = new GridBagConstraints();
+        c.gridx = 0;
+        c.gridy = 3;
+        c.weightx = 1.0; 
+        c.weighty = 0.0; 
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.anchor = GridBagConstraints.LINE_START;
+        panel.add(commandPanel, c);
+
+    }
+
+
+    private void loadIdeStyle(){
+        Color colorBackground = JBColor.background();
+        Color colorForeground = JBColor.foreground();
+        Font font = UIManager.getFont("List.font");
+        panel.setBackground(colorBackground);
+        panel.setForeground(colorForeground);
+        panel.setFont(font);
+        scrollListPane.setBackground(colorBackground);
+        scrollListPane.setForeground(colorForeground);
+        scrollListPane.setFont(font);
+        scrollListPane.setBorder(null);
+        pathLabel.setFont(font);
+        pathLabel.setBackground(colorBackground);
+        getCommandTextField().setBackground(colorBackground);
+        getCommandTextField().setBorder(BorderFactory.createEmptyBorder());
+        getCommandTextField().setDisabledTextColor(Color.WHITE);
+        getCommandTextField().setFont(font);
+    }
+
+    JLabel getCommandLabel() {
+        return commandPanel.getCommandLabel();
+    }
+
+    JLabel getPathLabel() {
+        return pathLabel;
+    }
+
+    CommandTextField getCommandTextField() {
+        return commandPanel.getCommandTextField();
+    }
+
+    JPanel getPanel() {
+        return panel;
+    }
+
+    JScrollPane getScrollListPane(){
+        return this.scrollListPane;
+    }
+
+}

--- a/src/main/java/com/crhistianm/netrwoon/utils/CommandOperationType.java
+++ b/src/main/java/com/crhistianm/netrwoon/utils/CommandOperationType.java
@@ -1,0 +1,9 @@
+package com.crhistianm.netrwoon.utils;
+
+public enum CommandOperationType {
+    NONE,
+    CREATE_FILE,
+    CREATE_DIRECTORY,
+    DELETE_SELECTED,
+    RENAME_SELECTED
+}

--- a/src/main/java/com/crhistianm/netrwoon/utils/Constants.java
+++ b/src/main/java/com/crhistianm/netrwoon/utils/Constants.java
@@ -1,0 +1,10 @@
+package com.crhistianm.netrwoon.utils;
+
+public class Constants {
+
+    public static final String MAIN_VIEW_NAME = "Netrwoon";
+
+    public static final String HELP_LABEL_TEXT = "Quick Help: -:go up dir  D:delete  R:rename %:create file d:create directory esc:exit";
+
+    
+}


### PR DESCRIPTION
Provides the following main window components:

- Custom text field for matching current operation.
- Personalized panel for completing selected operation.
- `NetrwoonMainView` contains both custom text field and panel while adding help label.
- `NetrwoonDialogWrapper` is the actual parent component that will be displayed and accessed.

No settings are implemented yet.
