### PR TITLE
Show list of files by current directory

### DIFF
--- a/src/main/java/com/crhistianm/netrwoon/controllers/NetrwoonController.java
+++ b/src/main/java/com/crhistianm/netrwoon/controllers/NetrwoonController.java
@@ -1,0 +1,47 @@
+package com.crhistianm.netrwoon.controllers;
+
+
+
+import javax.swing.DefaultListModel;
+
+import com.crhistianm.netrwoon.components.NetrwoonDialogWrapper;
+import com.crhistianm.netrwoon.services.NetrwoonService;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBList;
+
+public class NetrwoonController{
+
+    private JBList<String> list;
+
+    private final NetrwoonService service;
+
+    private NetrwoonDialogWrapper dialog;
+
+    Project project;
+
+    public NetrwoonController(Project project, NetrwoonService service) {
+        this.service = service;
+        this.project = project;
+
+
+        DefaultListModel<String> actualList = service.getList();
+
+        list = new JBList<>(actualList);
+        list.setFocusable(true);
+        dialog = new NetrwoonDialogWrapper(list, project);
+
+        selectFirstIndex();
+    }
+
+    public void showDialog() {
+        this.dialog.show();
+    }
+
+    private void selectFirstIndex(){
+        if(list.getModel().getSize() != 0) list.setSelectedIndex(0);
+    }
+
+
+    
+}

--- a/src/main/java/com/crhistianm/netrwoon/services/NetrwoonService.java
+++ b/src/main/java/com/crhistianm/netrwoon/services/NetrwoonService.java
@@ -1,0 +1,83 @@
+package com.crhistianm.netrwoon.services;
+
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.swing.DefaultListModel;
+
+import com.crhistianm.netrwoon.states.NetrwoonState;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+
+@Service(Service.Level.PROJECT)
+public final class NetrwoonService {
+
+    private final NetrwoonState state; 
+
+    public NetrwoonService(FileEditorManager fileEditorManager, NetrwoonState state) {
+        this.state = state;
+    }
+
+    public NetrwoonService(Project project) {
+        this.state = new NetrwoonState();
+    }
+
+    private void loadList(){
+        state.getCurrentDirectoryList().clear();
+        Arrays.stream(state.getCurrentDirectory().getChildren()).forEach(file -> {
+            if(file.isDirectory()){
+                state.getCurrentDirectoryList().addElement(file.getName() + "/");
+            }
+            if(!file.isDirectory()){
+                state.getCurrentDirectoryList().addElement(file.getName());
+            }
+        });
+        sortListByDirectory();
+    }
+
+    private void sortListByDirectory(){
+        List<String> temp = Arrays.stream(state.getCurrentDirectoryList().toArray()).map(String::valueOf).collect(Collectors.toList());
+        temp.sort(new CustomComparator());
+        state.getCurrentDirectoryList().clear();
+        temp.forEach(state.getCurrentDirectoryList()::addElement);
+    }
+
+    private class CustomComparator implements Comparator<String>{
+
+        @Override
+        public int compare(String o1, String o2) {
+            int result = 0;
+            if(o1.contains("/")) result -=1;
+            if(o2.contains("/")) result += 1;
+            if(result == 0) result = o1.compareTo(o2);
+
+            return result;
+        }
+
+    }
+
+
+    public DefaultListModel<String> getList() {
+        return this.state.getCurrentDirectoryList();
+    }
+
+    public String getCurrentPath() {
+        return this.state.getCurrentDirectory().getPath();
+    }
+
+
+    public void setCurrentDirectory(VirtualFile currentDirectory) {
+        this.state.setCurrentDirectory(currentDirectory);
+        loadList();
+    }
+
+    private String removeSlash(String arg){ 
+        return arg.replace("/", ""); 
+    }
+
+}

--- a/src/main/java/com/crhistianm/netrwoon/states/NetrwoonState.java
+++ b/src/main/java/com/crhistianm/netrwoon/states/NetrwoonState.java
@@ -1,0 +1,33 @@
+package com.crhistianm.netrwoon.states;
+
+
+import javax.swing.DefaultListModel;
+
+import com.intellij.openapi.vfs.VirtualFile;
+
+public class NetrwoonState {
+
+    private VirtualFile currentDirectory;
+
+    private DefaultListModel<String> currentDirectoryList = new DefaultListModel<>();
+
+    public NetrwoonState() {}
+
+    public VirtualFile getCurrentDirectory() {
+        return currentDirectory;
+    }
+
+    public void setCurrentDirectory(VirtualFile currentDirectory) {
+        this.currentDirectory = currentDirectory;
+    }
+
+    public DefaultListModel<String> getCurrentDirectoryList() {
+        return currentDirectoryList;
+    }
+
+    public void setCurrentDirectoryList(DefaultListModel<String> currentDirectoryList) {
+        this.currentDirectoryList = currentDirectoryList;
+    }
+
+
+}


### PR DESCRIPTION
Provides a sorted list of file-system objects based on current directory described as the following:

- `NetrwoonState` contains both current directory and list of file-system-objects.
- `NetrwoonService` loads and sorts the list.
- `NetwoonController` only connects service and view to display the list.
- Directories are sorted first at the list alphabetically.
- Normal files are sorted after directories alphabetically.