### PR TITLE
Add release preparation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Prepare release
+
+on:
+  release:
+    types: [created] 
+  workflow_dispatch:
+
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v5
+
+      - run: ./gradlew buildPlugin
+
+      - name: Get Version
+        id: version
+        run: echo "VERSION=$(./gradlew properties --property version --quiet --console=plain)" >> $GITHUB_OUTPUT
+
+      - name: Rename Plugin Artifact
+        run: mv ./build/distributions/netrwoon*.zip ./build/distributions/netrwoon-${{ steps.version.outputs.VERSION }}.zip
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: netrwoon-plugin
+          path: ./build/distributions/netrwoon-${{ steps.version.outputs.VERSION }}.zip
+
+      - name: Create Draft Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          RELEASE_NOTES="${{ github.event.release.body }}"
+          if [ -z "$RELEASE_NOTES" ]; then
+            RELEASE_NOTES="Draft release for netrwoon plugin"
+          fi
+          gh release create $VERSION \
+            --draft \
+            --title "$VERSION" \
+            --notes "$RELEASE_NOTES"
+
+
+  publish_marketplace:
+    needs: draft_release
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v5
+
+      - name: Publish Plugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+        run: ./gradlew publishPlugin
+
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.crhistianm"
-version = "1.0-SNAPSHOT"
+version = "1.0.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Prepares trigger for publishing plugin to JetBrains marketplace.

- Changelog is obtained from manual release body.
- Version is obtained from build.gradle property.